### PR TITLE
Add blank space glyph to avoid showing [0020] box after glyphs when space is intended

### DIFF
--- a/bdf/siji.bdf
+++ b/bdf/siji.bdf
@@ -29,7 +29,7 @@ FONT_ASCENT 8
 COMMENT """"""""""""""""""""""Procon - An Iconic Font based on Stlarch font, Sm4tik's xbm pack, FontAwesome and Lokaltog Symbol Font""""""""""""""""""""""
 COMMENT ""Siji font - an iconic bitmap font based on Stlarch by Stark""
 ENDPROPERTIES
-CHARS 631
+CHARS 632
 STARTCHAR U+E000
 ENCODING 57344
 SWIDTH 1152 0
@@ -12016,6 +12016,25 @@ BITMAP
 1C00
 3400
 1000
+0000
+0000
+ENDCHAR
+STARTCHAR Non Glitching Space
+ENCODING 57975
+SWIDTH 1152 0
+DWIDTH 6 0
+BBX 8 12 0 -2
+BITMAP
+0000
+0000
+0000
+0000
+0000
+0000
+0000
+0000
+0000
+0000
 0000
 0000
 ENDCHAR


### PR DESCRIPTION
When an icon is followed by a space, instead of rendering a space in the default i3bar font, the space is instead rendered as [0020], since there is no space icon in this font. A workaround for this is to add a space glyph which can be used when a space is intended. I added this glyph as \uE277, and as far as I can tell it works as intended.

This is a solution (sort of) to issue #3 
