### PR TITLE
Use printf instead of cat to show success message.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -156,15 +156,15 @@ post_install()
 	else 
 		file="custom startup script that gets executed during xlogin"
 	fi
-cat << MSG
+printf "
   Successfully installed ${w}$(basename $pcf_font) -> ${font_dir}${rs}
   Add the following snippet in your ${file}:
 
     ${w}xset +fp ${font_dir}${rs}
     ${w}xset fp rehash${rs}
 
-  If it already exists then you can skip this step."
-MSG
+  If it already exists then you can skip this step.
+"
 }
 
 error()


### PR DESCRIPTION
Ensures that color codes are displayed properly.
This fixed https://github.com/stark/siji/issues/11 for me.