### PR TITLE
install.sh: Use XDG Base Directory standard for fonts directory.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,8 @@
 #              Smarter non-zero checking for font existence
 
 # Specify the font directory
-font_dir="$HOME/.fonts"
+XDG_DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
+font_dir="$XDG_DATA_HOME/fonts"
 
 # Specify the font
 font="siji"


### PR DESCRIPTION
Since `~/.fonts` has been deprecated (https://lists.freedesktop.org/archives/fontconfig/2014-July/005269.html), this patch installs the font in `$XDG_DATA_HOME/fonts`.